### PR TITLE
Use MemsqlAdapter instead of Mysql2Adapter

### DIFF
--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -23,7 +23,7 @@ module ActiveRecord
       end
 
       client = Mysql2::Client.new(config)
-      ConnectionAdapters::Mysql2Adapter.new(client, logger, nil, config)
+      ConnectionAdapters::MemsqlAdapter.new(client, logger, nil, config)
     rescue Mysql2::Error => error
       if error.message.include?("Unknown database")
         raise ActiveRecord::NoDatabaseError


### PR DESCRIPTION
Hi.

Creating an instance of `Mysql2Adapter` here seems to be a mistake.
Instead, `MemsqlAdapter` should be created here.