### PR TITLE
Support Rails 6

### DIFF
--- a/activerecord-memsql.gemspec
+++ b/activerecord-memsql.gemspec
@@ -33,5 +33,5 @@ This adapter is a customized version of the mysql2 adapter to provide support fo
   spec.add_development_dependency "minitest", "~> 5.0"
 
   spec.add_dependency "activerecord", ">= 4.0.0"
-  spec.add_dependency "mysql2", ">= 0.4.2", "< 0.5"
+  spec.add_dependency "mysql2", ">= 0.4.4"
 end

--- a/activerecord-memsql.gemspec
+++ b/activerecord-memsql.gemspec
@@ -32,6 +32,6 @@ This adapter is a customized version of the mysql2 adapter to provide support fo
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 
-  spec.add_dependency "activerecord", ">= 4.0.0"
+  spec.add_dependency "activerecord", ">= 6.0.0"
   spec.add_dependency "mysql2", ">= 0.4.4"
 end

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -113,19 +113,19 @@ module ActiveRecord
 
       private
 
-      def connect
-        @connection = Mysql2::Client.new(@config)
-        configure_connection
-      end
+        def connect
+          @connection = Mysql2::Client.new(@config)
+          configure_connection
+        end
 
-      def configure_connection
-        @connection.query_options.merge!(as: :array)
-        super
-      end
+        def configure_connection
+          @connection.query_options.merge!(as: :array)
+          super
+        end
 
-      def full_version
-        @full_version ||= @connection.server_info[:version]
-      end
+        def full_version
+          @full_version ||= @connection.server_info[:version]
+        end
     end
   end
 end

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -42,8 +42,8 @@ module ActiveRecord
       include MySQL::DatabaseStatements
 
       def initialize(connection, logger, connection_options, config)
-        super
-        @prepared_statements = false unless config.key?(:prepared_statements)
+        superclass_config = config.reverse_merge(prepared_statements: false)
+        super(connection, logger, connection_options, superclass_config)
         configure_connection
       end
 

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -4,9 +4,7 @@ require "active_record/connection_adapters/abstract_mysql_adapter"
 require "active_record/connection_adapters/mysql2_adapter"
 require "active_record/connection_adapters/mysql/database_statements"
 
-gem "mysql2", ">= 0.3.18", "< 0.5"
-require "mysql2"
-raise "mysql2 0.4.3 is not supported. Please upgrade to 0.4.4+" if Mysql2::VERSION == "0.4.3"
+gem "mysql2", ">= 0.4.4"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record/connection_adapters/abstract_mysql_adapter"
 require "active_record/connection_adapters/mysql2_adapter"
 require "active_record/connection_adapters/mysql/database_statements"
@@ -17,7 +19,7 @@ module ActiveRecord
       config[:variables] = {sql_mode: ''} if config[:variables].nil?
 
       if config[:flags].kind_of? Array
-        config[:flags].push "FOUND_ROWS".freeze
+        config[:flags].push "FOUND_ROWS"
       else
         config[:flags] |= Mysql2::Client::FOUND_ROWS
       end
@@ -35,7 +37,7 @@ module ActiveRecord
 
   module ConnectionAdapters
     class MemsqlAdapter < AbstractMysqlAdapter
-      ADAPTER_NAME = "MemSQL".freeze
+      ADAPTER_NAME = "MemSQL"
 
       include MySQL::DatabaseStatements
 

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -61,6 +61,10 @@ module ActiveRecord
         true
       end
 
+      def supports_lazy_transactions?
+        true
+      end
+
       def supports_advisory_locks?
         false
       end

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -45,6 +45,12 @@ module ActiveRecord
         configure_connection
       end
 
+      def self.database_exists?(config)
+        !!ActiveRecord::Base.memsql_connection(config)
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
+
       def supports_json?
         !mariadb? && database_version >= "5.7.8"
       end

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -46,7 +46,7 @@ module ActiveRecord
       end
 
       def supports_json?
-        !mariadb? && version >= "5.7.8"
+        !mariadb? && database_version >= "5.7.8"
       end
 
       def supports_comments?
@@ -134,7 +134,11 @@ module ActiveRecord
         end
 
         def full_version
-          @full_version ||= @connection.server_info[:version]
+          schema_cache.database_version.full_version_string
+        end
+
+        def get_full_version
+          @connection.server_info[:version]
         end
     end
   end

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -125,7 +125,7 @@ module ActiveRecord
         end
 
         def configure_connection
-          @connection.query_options.merge!(as: :array)
+          @connection.query_options[:as] = :array
           super
         end
 

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -113,6 +113,12 @@ module ActiveRecord
         @connection.close
       end
 
+      def discard! # :nodoc:
+        super
+        @connection.automatic_close = false
+        @connection = nil
+      end
+
       private
 
         def connect

--- a/lib/active_record/connection_adapters/memsql_adapter.rb
+++ b/lib/active_record/connection_adapters/memsql_adapter.rb
@@ -8,6 +8,8 @@ gem "mysql2", ">= 0.4.4"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
+    ER_BAD_DB_ERROR = 1049
+
     # Establishes a connection to the database that's used by all Active Record objects.
     def memsql_connection(config)
       config = config.symbolize_keys
@@ -25,7 +27,7 @@ module ActiveRecord
       client = Mysql2::Client.new(config)
       ConnectionAdapters::MemsqlAdapter.new(client, logger, nil, config)
     rescue Mysql2::Error => error
-      if error.message.include?("Unknown database")
+      if error.error_number == ER_BAD_DB_ERROR
         raise ActiveRecord::NoDatabaseError
       else
         raise


### PR DESCRIPTION
This patch backports several changes in `lib/active_record/connection_adapters/mysql2_adapter.rb` from Rails 6.0. Among them is a breaking change in the adapter interface: https://github.com/rails/rails/commit/6584fb3.